### PR TITLE
Fix documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About py-rattler-build-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/py-rattler-build-feedstock/blob/main/LICENSE.txt)
 
-Home: http://rattler.build/
+Home: https://rattler.build/
 
 Package license: BSD-3-Clause
 
@@ -11,7 +11,7 @@ Summary: The fastest way to build conda packages programatically
 
 Development: https://github.com/prefix-dev/rattler-build
 
-Documentation: https://rattler.build/latest/reference/python_bindings/
+Documentation: https://rattler.build/latest/py-rattler-build/reference/
 
 The `rattler-build` tooling and library creates cross-platform relocatable
 binaries / packages from a simple recipe format. The recipe format is heavily

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 945b865915e8292fdf378358e46ea168592c391099152421821b03b90d7d4b0e
 
 build:
-  number: 0
+  number: 1
   skip: not (match(python, python_min ~ ".*") and is_abi3) or (target_platform == "linux-ppc64le")
   python:
     version_independent: true
@@ -50,7 +50,7 @@ tests:
       pip_check: true
 
 about:
-  homepage: http://rattler.build/
+  homepage: https://rattler.build/
   summary: 'The fastest way to build conda packages programatically'
   description: |
     The `rattler-build` tooling and library creates cross-platform relocatable
@@ -61,7 +61,7 @@ about:
   license_file:
     - LICENSE
     - THIRDPARTY.yml
-  documentation: https://rattler.build/latest/reference/python_bindings/
+  documentation: https://rattler.build/latest/py-rattler-build/reference/
   repository: https://github.com/prefix-dev/rattler-build
 
 extra:


### PR DESCRIPTION
Hey all, I noticed that the documentation URL was broken.

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
